### PR TITLE
Minor polishing

### DIFF
--- a/plugins/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
@@ -16,8 +16,6 @@
 
 import com.android.build.api.dsl.ApplicationExtension
 import no.nordicsemi.android.buildlogic.configureAndroidCompose
-import no.nordicsemi.android.buildlogic.getVersionCodeFromTags
-import no.nordicsemi.android.buildlogic.getVersionNameFromTags
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
@@ -28,11 +26,6 @@ class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
             pluginManager.apply("com.android.application")
             val extension = extensions.getByType<ApplicationExtension>()
             configureAndroidCompose(extension)
-
-            extension.defaultConfig {
-                versionName = target.getVersionNameFromTags()
-                versionCode = target.getVersionCodeFromTags()
-            }
         }
     }
 }

--- a/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -18,10 +18,13 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import no.nordicsemi.android.buildlogic.configureKotlinAndroid
 import no.nordicsemi.android.buildlogic.configurePrintApksTask
+import no.nordicsemi.android.buildlogic.getVersionCodeFromTags
+import no.nordicsemi.android.buildlogic.getVersionNameFromTags
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 
+@Suppress("UnstableApiUsage")
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
@@ -33,8 +36,13 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             extensions.configure<ApplicationExtension> {
                 configureKotlinAndroid(this)
                 compileSdk = 33
-                defaultConfig.minSdk = 24
-                defaultConfig.targetSdk = 33
+
+                defaultConfig {
+                    minSdk = 24
+                    targetSdk = 33
+                    versionName = target.getVersionNameFromTags()
+                    versionCode = target.getVersionCodeFromTags()
+                }
 
                 signingConfigs {
                     create("release") {
@@ -59,5 +67,4 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             }
         }
     }
-
 }

--- a/plugins/src/main/kotlin/AndroidFeatureConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidFeatureConventionPlugin.kt
@@ -31,8 +31,8 @@ class AndroidFeatureConventionPlugin : Plugin<Project> {
             val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
             dependencies {
-                add("implementation", libs.findLibrary("coil.kt").get())
-                add("implementation", libs.findLibrary("coil.kt.compose").get())
+                // add("implementation", libs.findLibrary("coil.kt").get())
+                // add("implementation", libs.findLibrary("coil.kt.compose").get())
 
                 add("implementation", libs.findLibrary("androidx.hilt.navigation.compose").get())
                 add("implementation", libs.findLibrary("androidx.lifecycle.runtimeCompose").get())

--- a/plugins/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -30,9 +30,9 @@ class AndroidHiltConventionPlugin : Plugin<Project> {
 
             val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
             dependencies {
-                "implementation"(libs.findLibrary("hilt.android").get())
-                "kapt"(libs.findLibrary("hilt.compiler").get())
-                "kaptAndroidTest"(libs.findLibrary("hilt.compiler").get())
+                add("implementation", libs.findLibrary("hilt.android").get())
+                add("kapt", libs.findLibrary("hilt.compiler").get())
+                add("kaptAndroidTest", libs.findLibrary("hilt.compiler").get())
             }
         }
     }

--- a/plugins/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -28,5 +28,4 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
             configureAndroidCompose(extension)
         }
     }
-
 }

--- a/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 
+@Suppress("UnstableApiUsage")
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {

--- a/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/AndroidCompose.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/AndroidCompose.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("UnstableApiUsage")
+
 package no.nordicsemi.android.buildlogic
 
 import com.android.build.api.dsl.CommonExtension

--- a/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/PrintTestApks.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/PrintTestApks.kt
@@ -14,6 +14,8 @@
  *   limitations under the License.
  */
 
+@file:Suppress("UnstableApiUsage")
+
 package no.nordicsemi.android.buildlogic
 
 import com.android.build.api.artifact.SingleArtifact

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 /*
  * Copyright 2022 The Android Open Source Project
  *


### PR DESCRIPTION
The only important thing this PR does is moving `versionName` and `versionCode` from Android Application Compose to Android Application plugin.
Rest is just polishing and suppressing warnings.