### PR TITLE
Moving kotlin configuration to separate plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ nordic-mcumgr = "1.5.2"
 nordic-scanner = "1.6.0"
 nordic-common = "1.3.7"
 nordic-memfault = "1.0.2"
-nordicPlugins = "1.0.19"
+nordicPlugins = "1.0.20"
 
 [libraries]
 accompanist-flowlayout = { group = "com.google.accompanist", name = "accompanist-flowlayout", version.ref = "accompanist" }
@@ -181,6 +181,7 @@ nordic-library = { id = "no.nordicsemi.android.gradle.library", version.ref = "n
 nordic-library-compose = { id = "no.nordicsemi.android.gradle.library.compose", version.ref = "nordicPlugins" }
 nordic-feature = { id = "no.nordicsemi.android.gradle.feature", version.ref = "nordicPlugins" }
 nordic-hilt = { id = "no.nordicsemi.android.gradle.hilt", version.ref = "nordicPlugins" }
+nordic-kotlin = { id = "no.nordicsemi.android.gradle.kotlin", version.ref = "nordicPlugins" }
 nordic-nexus = { id = "no.nordicsemi.android.gradle.nexus", version.ref = "nordicPlugins" }
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -97,6 +97,12 @@ gradlePlugin {
             description = "Plugin enabling Hilt"
             implementationClass = "AndroidHiltConventionPlugin"
         }
+        register("kotlin") {
+            id = "no.nordicsemi.android.gradle.kotlin"
+            displayName = "Kotlin plugin"
+            description = "Plugin enabling Kotlin"
+            implementationClass = "AndroidKotlinConventionPlugin"
+        }
         register("nexus") {
             id = "no.nordicsemi.android.gradle.nexus"
             displayName = "Nexus plugin"

--- a/plugins/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidApplicationComposeConventionPlugin.kt
@@ -42,6 +42,7 @@ class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("no.nordicsemi.android.gradle.application")
+                apply("no.nordicsemi.android.gradle.kotlin")
             }
 
             val extension = extensions.getByType<ApplicationExtension>()

--- a/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -45,11 +45,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("com.android.application")
-                apply("org.jetbrains.kotlin.android")
             }
 
             extensions.configure<ApplicationExtension> {
-                configureKotlinAndroid(this)
                 compileSdk = 33
 
                 defaultConfig {

--- a/plugins/src/main/kotlin/AndroidHiltConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidHiltConventionPlugin.kt
@@ -39,6 +39,7 @@ class AndroidHiltConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
+                apply("no.nordicsemi.android.gradle.kotlin")
                 apply("org.jetbrains.kotlin.kapt")
                 apply("dagger.hilt.android.plugin")
             }

--- a/plugins/src/main/kotlin/AndroidKotlinConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidKotlinConventionPlugin.kt
@@ -29,60 +29,24 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
+import no.nordicsemi.android.buildlogic.configureAndroidCompose
 import no.nordicsemi.android.buildlogic.configureKotlinAndroid
-import no.nordicsemi.android.buildlogic.configurePrintApksTask
-import no.nordicsemi.android.buildlogic.getVersionCodeFromTags
-import no.nordicsemi.android.buildlogic.getVersionNameFromTags
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 
-@Suppress("UnstableApiUsage")
-class AndroidLibraryConventionPlugin : Plugin<Project> {
+class AndroidKotlinConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply("com.android.library")
+                apply("org.jetbrains.kotlin.android")
             }
 
-            extensions.configure<LibraryExtension> {
-                compileSdk = 33
-
-                defaultConfig {
-                    minSdk = 21
-                    targetSdk = 33
-                }
-
-                buildTypes {
-                    getByName("release") {
-                        isMinifyEnabled = true
-                        consumerProguardFile("module-rules.pro")
-                        buildConfigField("String", "VERSION_NAME", "\"${getVersionNameFromTags()}\"")
-                        buildConfigField("String", "VERSION_CODE", "\"${getVersionCodeFromTags()}\"")
-                    }
-
-                    getByName("debug") {
-                        buildConfigField("String", "VERSION_NAME", "\"debug\"")
-                        buildConfigField("String", "VERSION_CODE", "\"${getVersionCodeFromTags()}\"")
-                    }
-                }
-            }
-
-            extensions.configure<LibraryAndroidComponentsExtension> {
-                configurePrintApksTask(this)
-            }
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-            configurations.configureEach {
-                resolutionStrategy {
-                    force(libs.findLibrary("junit4").get())
-                    // Temporary workaround for https://issuetracker.google.com/174733673
-                    force("org.objenesis:objenesis:2.6")
-                }
-            }
+            val extension = extensions.getByType<LibraryExtension>()
+            configureKotlinAndroid(extension)
         }
     }
 }

--- a/plugins/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -42,6 +42,7 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("no.nordicsemi.android.gradle.library")
+                apply("no.nordicsemi.android.gradle.kotlin")
             }
 
             val extension = extensions.getByType<LibraryExtension>()

--- a/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/KotlinAndroid.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/KotlinAndroid.kt
@@ -48,12 +48,6 @@ internal fun Project.configureKotlinAndroid(
     commonExtension: CommonExtension<*, *, *, *>,
 ) {
     commonExtension.apply {
-        compileSdk = 33
-
-        defaultConfig {
-            minSdk = 21
-        }
-
         compileOptions {
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
This PR decouples kotlin dependency from *nordic.library* and *nordic.application* plugins.