### PR TITLE
Adding Javadoc in publications

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,16 +33,3 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
-
-GROUP=no.nordicsemi.android.gradle
-POM_DESCRIPTION=Nordic Android Common Libraries
-POM_URL=https://github.com/NordicSemiconductor/Android-Gradle-Plugins
-POM_SCM_URL=https://github.com/NordicSemiconductor/Android-Gradle-Plugins
-POM_SCM_CONNECTION=scm:git@github.com:NordicSemiconductor/Android-Gradle-Plugins.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:NordicSemiconductor/Android-Gradle-Plugins.git
-POM_LICENCE=BSD-3-Clause
-POM_LICENCE_NAME=The BSD 3-Clause License
-POM_LICENCE_URL=http://opensource.org/licenses/BSD-3-Clause
-POM_DEVELOPER_ID=syzi
-POM_DEVELOPER_NAME=Sylwester Zielinski
-POM_DEVELOPER_EMAIL=sylwester.zielinski@nordicsemi.no

--- a/plugins/src/main/kotlin/AndroidNexusRepositoryPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidNexusRepositoryPlugin.kt
@@ -69,6 +69,7 @@ class AndroidNexusRepositoryPlugin : Plugin<Project> {
             library.publishing {
                 singleVariant("release") {
                     withSourcesJar()
+                    withJavadocJar()
                 }
             }
 

--- a/plugins/src/main/kotlin/KotlinNexusRepositoryPlugin.kt
+++ b/plugins/src/main/kotlin/KotlinNexusRepositoryPlugin.kt
@@ -89,7 +89,7 @@ class KotlinNexusRepositoryPlugin : Plugin<Project> {
                                 groupId = POM_GROUP ?: group.toString()
                             }
                             // Set the component to be published.
-                            from(components["kotlin"])
+                            from(components["java"])
                             // Apply POM configuration.
                             pom {
                                 from(nexusPluginExt)

--- a/plugins/src/main/kotlin/KotlinNexusRepositoryPlugin.kt
+++ b/plugins/src/main/kotlin/KotlinNexusRepositoryPlugin.kt
@@ -67,6 +67,7 @@ class KotlinNexusRepositoryPlugin : Plugin<Project> {
 
             // Create a software component with the release variant.
             library.withSourcesJar()
+            library.withJavadocJar()
 
             afterEvaluate {
                 publishing {


### PR DESCRIPTION
This PR fixes an issue with missing Javadoc in Android and Kotlin publications and adds Sources to Kotlin publication.
Apparently the "kotlin" component does not have sources, but "java" does.