### PR TITLE
Release script migrated to Retrofit 2.11

### DIFF
--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -34,7 +34,8 @@ plugins {
     `kotlin-dsl`
     `maven-publish`
     signing
-    id("com.gradle.plugin-publish") version "1.2.1"
+    alias(libs.plugins.publish)
+    alias(libs.plugins.ksp)
 }
 apply(from = "../gradle/git-tag-version.gradle")
 
@@ -148,7 +149,8 @@ signing {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp:okhttp:2.7.5")
-    implementation("com.squareup.retrofit2:retrofit:2.11.0")
-    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation(libs.okhttp)
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.converter.moshi)
+    ksp(libs.moshi.kotlin.codegen)
 }

--- a/plugins/src/main/kotlin/no/nordicsemi/android/tasks/HttpLoggingInterceptor.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/tasks/HttpLoggingInterceptor.kt
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.tasks
 
-import com.squareup.okhttp.HttpUrl
-import com.squareup.okhttp.Protocol
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
+import okhttp3.Protocol
 import okhttp3.Response
 import okio.Buffer
 import java.io.IOException
@@ -50,17 +50,17 @@ class HttpLoggingInterceptor @JvmOverloads constructor(private val logger: Logge
         }
         val logBody = level == Level.BODY
         val logHeaders = logBody || level == Level.HEADERS
-        val requestBody = request.body()
+        val requestBody = request.body
         val hasRequestBody = requestBody != null
         if (logHeaders) {
-            val headers = request.headers()
+            val headers = request.headers
             var i = 0
-            val count = headers.size()
+            val count = headers.size
             while (i < count) {
                 logger.log(headers.name(i) + ": " + headers.value(i))
                 i++
             }
-            var endMessage: String = "--> END " + request.method()
+            var endMessage: String = "--> END " + request.method
             if (logBody && hasRequestBody) {
                 val buffer = Buffer()
                 requestBody!!.writeTo(buffer)
@@ -74,30 +74,30 @@ class HttpLoggingInterceptor @JvmOverloads constructor(private val logger: Logge
             logger.log(endMessage)
         }
         val response = chain.proceed(request)
-        val responseBody = response.body()
+        val responseBody = response.body
         if (logHeaders) {
-            val headers = response.headers()
+            val headers = response.headers
             var i = 0
-            val count = headers.size()
+            val count = headers.size
             while (i < count) {
                 logger.log(headers.name(i) + ": " + headers.value(i))
                 i++
             }
             var endMessage: String = "<-- END HTTP"
             if (logBody) {
-                val source = responseBody?.source()
-                source?.request(Long.MAX_VALUE) // Buffer the entire body.
-                val buffer = source?.buffer
+                val source = responseBody.source()
+                source.request(Long.MAX_VALUE) // Buffer the entire body.
+                val buffer = source.buffer
                 var charset: Charset? = UTF8
-                val contentType = responseBody?.contentType()
+                val contentType = responseBody.contentType()
                 if (contentType != null) {
                     charset = contentType.charset(UTF8)
                 }
-                if (responseBody?.contentLength() != 0L) {
+                if (responseBody.contentLength() != 0L) {
                     logger.log("")
-                    logger.log(buffer?.clone()?.readString((charset)!!))
+                    logger.log(buffer.clone().readString((charset)!!))
                 }
-                endMessage += " (" + buffer?.size + "-byte body)"
+                endMessage += " (" + buffer.size + "-byte body)"
             }
             logger.log(endMessage)
         }
@@ -111,8 +111,8 @@ class HttpLoggingInterceptor @JvmOverloads constructor(private val logger: Logge
         }
 
         private fun requestPath(url: HttpUrl): String {
-            val path = url.encodedPath()
-            val query = url.encodedQuery()
+            val path = url.encodedPath
+            val query = url.encodedQuery
             return if (query != null) ("$path?$query") else path
         }
     }

--- a/plugins/src/main/kotlin/no/nordicsemi/android/tasks/ReleaseStagingRepositoriesTask.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/tasks/ReleaseStagingRepositoriesTask.kt
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.tasks
 
-import com.squareup.okhttp.Credentials
+import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
@@ -69,7 +69,7 @@ open class ReleaseStagingRepositoriesTask : DefaultTask() {
             throw HttpException(releaseResponse)
         }
 
-        Thread.sleep(120000) //Wait for the repository to close. Been too lazy to write retry mechanism.
+        Thread.sleep(120000) //Wait for the repository to be released. Been too lazy to write retry mechanism.
 
         val dropResponse = service.dropStagingRepositories(requestBody).execute()
 

--- a/plugins/src/main/kotlin/no/nordicsemi/android/tasks/StagingRepositoriesRequestBody.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/tasks/StagingRepositoriesRequestBody.kt
@@ -1,11 +1,14 @@
 package no.nordicsemi.android.tasks
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 data class StagingRepositoriesRequestBody(
     @field:Json(name = "data") val data: StagingRepositoriesRequest
 )
 
+@JsonClass(generateAdapter = true)
 data class StagingRepositoriesRequest(
     @field:Json(name = "description")
     val description: String = "",

--- a/plugins/src/main/kotlin/no/nordicsemi/android/tasks/StagingRepositoryResponseBody.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/tasks/StagingRepositoryResponseBody.kt
@@ -1,11 +1,14 @@
 package no.nordicsemi.android.tasks
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = true)
 data class StagingRepositoryResponseBody(
     @field:Json(name = "data") val data: List<StagingRepositoryResponse>
 )
 
+@JsonClass(generateAdapter = true)
 data class StagingRepositoryResponse(
     @field:Json(name = "repositoryId") val id: String
 )


### PR DESCRIPTION
## Issue

After updating Retrofit from 2.9 to 2.11 release script was failing with the following error:
```
Execution failed for task ':releaseStagingRepositories'.
> Unable to create converter for class no.nordicsemi.android.tasks.StagingRepositoryResponseBody
      for method SonatypeService.getStagingRepositories
```

## Changes

1. `ksp(libs.moshi.kotlin.codegen)` added
2. Request and Response classes annotated using `@JsonClass(generateAdapter = true)`
3. Migration to new okhttp