### PR TITLE
SLF4J migrastion

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,8 +56,8 @@ chart = "v3.1.0"
 leakcanary = "2.14"
 mockk = "1.13.11"
 truth = "1.4.3"
-slf4j = "1.7.36" # don't update to 2.x, unless the next one is also updated
-slf4j-timber = "3.1" # <- this one
+slf4j = "2.0.13"
+slf4j-timber = "1.1"
 robolectric = "4.12.2"
 skydovesBallon = "1.6.5"
 moshi = "1.15.1"
@@ -195,7 +195,7 @@ leakcanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", v
 slf4j = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
 slf4j-nop = { group = "org.slf4j", name = "slf4j-nop", version.ref = "slf4j" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
-slf4j-timber = { group = "com.arcao", name = "slf4j-timber", version.ref = "slf4j-timber" }
+slf4j-timber = { group = "uk.kulikov", name = "slf4j2-timber", version.ref = "slf4j-timber" }
 test-mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 test-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 skydoves-ballon = { group = "com.github.skydoves", name = "balloon-compose", version.ref = "skydovesBallon" }

--- a/renovate.json
+++ b/renovate.json
@@ -14,14 +14,6 @@
         "org.jetbrains.kotlin.*"
       ],
       "groupName": "kotlin"
-    },
-    {
-      "matchPackageNames": [
-        "org.slf4j:slf4j-api",
-        "org.slf4j:slf4j-nop",
-        "org.slf4j:slf4j-simple"
-      ],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Thanks to @LionZXY and https://github.com/LionZXY/slf4j2-timber it's now possible to use latest version of SLF4J and Timber.