### PR TITLE
Migration to OSSRH staging API

### DIFF
--- a/gradle/publish-root.gradle
+++ b/gradle/publish-root.gradle
@@ -2,6 +2,7 @@
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             stagingProfileId = System.env.SONATYPE_STAGING_PROFILE_ID
             username = System.env.OSSR_USERNAME
             password = System.env.OSSR_PASSWORD

--- a/plugins/src/main/kotlin/AndroidNexusRepositoryPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidNexusRepositoryPlugin.kt
@@ -149,8 +149,8 @@ class AndroidNexusRepositoryPlugin : Plugin<Project> {
                 publishing {
                     repositories {
                         maven {
-                            name = "sonatype"
-                            setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                            name = "ossrh-staging-api"
+                            setUrl("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                             credentials {
                                 username = System.getenv("OSSR_USERNAME")
                                 password = System.getenv("OSSR_PASSWORD")

--- a/plugins/src/main/kotlin/JvmNexusRepositoryPlugin.kt
+++ b/plugins/src/main/kotlin/JvmNexusRepositoryPlugin.kt
@@ -145,8 +145,8 @@ class JvmNexusRepositoryPlugin : Plugin<Project> {
                 publishing {
                     repositories {
                         maven {
-                            name = "sonatype"
-                            setUrl("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+                            name = "ossrh-staging-api"
+                            setUrl("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
                             credentials {
                                 username = System.getenv("OSSR_USERNAME")
                                 password = System.getenv("OSSR_PASSWORD")


### PR DESCRIPTION
This PR replaces the URLs following the migration giude:
https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

Fingers crossed!

Mind, that username and token must be changed to those from [Sonatype Central](https://central.sonatype.org/publish/generate-portal-token/).