### PR TITLE
Skip Room and Hilt compiler in Renovate updates (bumped to min API 23)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,9 @@
     },
     {
       "matchPackageNames": [
-        "com.google.firebase:firebase-bom"
+        "com.google.firebase:firebase-bom",
+        "androidx.room",
+        "androidx.hilt"
       ],
       "enabled": false
     }


### PR DESCRIPTION
Until we migrate to `minSdk = 23`, stop updating some dependencies.