### PR TITLE
Adding SPDX SBOM file generation

### DIFF
--- a/gradle/libs.versions.21.toml
+++ b/gradle/libs.versions.21.toml
@@ -87,6 +87,7 @@ dokkaPlugin = "2.2.0"
 googleServicesPlugins = "4.4.2"
 firebaseCrashlyticsPlugins = "3.0.2"
 kmmIosPublishPlugin = "2.0.3"
+spdxPlugin = "0.11.0" # https://github.com/spdx/spdx-gradle-plugin
 
 [libraries]
 accompanist-placeholder = { group = "com.google.accompanist", name = "accompanist-placeholder-material", version.ref = "accompanistPlaceholder" }
@@ -247,6 +248,7 @@ hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-p
 dokka-gradlePlugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokkaPlugin" }
 dokka-android-gradlePlugin = { group = "org.jetbrains.dokka", name = "android-documentation-plugin", version.ref = "dokkaPlugin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+spdx-gradlePlugin = { group = "org.spdx", name = "spdx-gradle-plugin", version.ref = "spdxPlugin" }
 
 [plugins]
 # Base plugins
@@ -287,3 +289,4 @@ wire = { id = "com.squareup.wire", version.ref = "wirePlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugins" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugins" }
 kmm-ios-publish = { id = "com.chromaticnoise.multiplatform-swiftpackage", version.ref = "kmmIosPublishPlugin" }
+spdx = { id = "org.spdx.sbom", version.ref = "spdxPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,6 +88,7 @@ dokkaPlugin = "2.2.0"
 googleServicesPlugins = "4.4.2"
 firebaseCrashlyticsPlugins = "3.0.2"
 kmmIosPublishPlugin = "2.0.3"
+spdxPlugin = "0.11.0" # https://github.com/spdx/spdx-gradle-plugin
 
 [libraries]
 accompanist-placeholder = { group = "com.google.accompanist", name = "accompanist-placeholder-material", version.ref = "accompanistPlaceholder" }
@@ -249,6 +250,7 @@ hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-p
 dokka-gradlePlugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokkaPlugin" }
 dokka-android-gradlePlugin = { group = "org.jetbrains.dokka", name = "android-documentation-plugin", version.ref = "dokkaPlugin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+spdx-gradlePlugin = { group = "org.spdx", name = "spdx-gradle-plugin", version.ref = "spdxPlugin" }
 
 [plugins]
 # Base plugins
@@ -289,3 +291,4 @@ wire = { id = "com.squareup.wire", version.ref = "wirePlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServicesPlugins" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugins" }
 kmm-ios-publish = { id = "com.chromaticnoise.multiplatform-swiftpackage", version.ref = "kmmIosPublishPlugin" }
+spdx = { id = "org.spdx.sbom", version.ref = "spdxPlugin" }

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(libs.jetbrains.compose.gradlePlugin)
     implementation(libs.dokka.gradlePlugin)
     implementation(libs.dokka.android.gradlePlugin)
+    implementation(libs.spdx.gradlePlugin)
 }
 
 gradlePlugin {

--- a/plugins/src/main/kotlin/PublishAndroidConventionPlugin.kt
+++ b/plugins/src/main/kotlin/PublishAndroidConventionPlugin.kt
@@ -31,7 +31,9 @@
 
 import com.android.build.api.dsl.LibraryExtension
 import no.nordicsemi.android.NordicPublishingExtension
+import no.nordicsemi.android.buildlogic.getGitRevision
 import no.nordicsemi.android.buildlogic.getVersionNameFromTags
+import no.nordicsemi.android.fixSpdx
 import no.nordicsemi.android.from
 import no.nordicsemi.android.tasks.ReleaseStagingRepositoriesTask
 import org.gradle.api.Plugin
@@ -50,6 +52,7 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters
+import org.spdx.sbom.gradle.SpdxSbomExtension
 import java.util.Calendar
 
 class PublishAndroidConventionPlugin : Plugin<Project> {
@@ -61,10 +64,15 @@ class PublishAndroidConventionPlugin : Plugin<Project> {
                 apply("maven-publish")
                 apply("signing")
                 apply("org.jetbrains.dokka")
+                apply("org.spdx.sbom")
             }
+
+            val gitVersion = getVersionNameFromTags()
+            val gitRevision = getGitRevision()
 
             // Default Nordic group.
             group = "no.nordicsemi.android"
+            version = gitVersion
 
             val nordicPublishing = extensions.create("nordicPublishing", NordicPublishingExtension::class.java)
             val library = extensions.getByType<LibraryExtension>()
@@ -106,7 +114,7 @@ class PublishAndroidConventionPlugin : Plugin<Project> {
                     }
                 }
                 // Set the version.
-                moduleVersion.set(getVersionNameFromTags())
+                moduleVersion.set(gitVersion)
                 // Set the footer message.
                 pluginsConfiguration.named("html", DokkaHtmlPluginParameters::class.java) {
                     val year = Calendar.getInstance().get(Calendar.YEAR)
@@ -137,6 +145,28 @@ class PublishAndroidConventionPlugin : Plugin<Project> {
 
             // TODO Remove afterEvaluate when `artifactId` and `groupId` are converted to lazy properties.
             afterEvaluate {
+                // Configure SPDX SBOM generation.
+                extensions.configure<SpdxSbomExtension> {
+                    targets.register("release") {
+                        configurations.set(listOf("releaseRuntimeClasspath"))
+                        with (nordicPublishing) {
+                            scm {
+                                uri.set(pomScmUrl)
+                                revision.set(gitRevision)
+                            }
+                            document {
+                                name.set("$group:${pomArtifactId.get()}")
+                                namespace.set(pomUrl.map { "$it${pomArtifactId.get()}/$version/spdx" })
+                                creator.set(pomOrg.map { "Organization: $it" })
+                                packageSupplier.set(pomOrg.map { "Organization: $it" })
+                            }
+                        }
+                    }
+                }
+                val spdxTask = tasks.named("spdxSbomForRelease") {
+                    fixSpdx(project.group.toString(), nordicPublishing)
+                }
+
                 extensions.configure<PublishingExtension> {
                     repositories {
                         maven {
@@ -151,11 +181,13 @@ class PublishAndroidConventionPlugin : Plugin<Project> {
                     publications {
                         val publication = create("library", MavenPublication::class.java) {
                             // Set publication properties.
-                            version = getVersionNameFromTags()
                             with(nordicPublishing) {
                                 // TODO Use artifactId.set(pomArtifactId) when they are converted to Property
                                 artifactId = pomArtifactId.get()
+                                // TODO Same here
                                 groupId = pomGroup.getOrElse(group.toString())
+                                // TODO And here
+                                version = gitVersion
                             }
                             // Set the component to be published.
                             from(components["release"])
@@ -166,6 +198,12 @@ class PublishAndroidConventionPlugin : Plugin<Project> {
                             }
                             // Add Dokka HTML docs.
                             artifact(tasks.named("dokkaHtmlJar"))
+
+                            // Add SPDX SBOM.
+                            artifact(spdxTask) {
+                                classifier = "sbom"
+                                extension = "json"
+                            }
                         }
                         // This task will add *.asc files to the publication for all artifacts.
                         signing.sign(publication)

--- a/plugins/src/main/kotlin/PublishJvmConventionPlugin.kt
+++ b/plugins/src/main/kotlin/PublishJvmConventionPlugin.kt
@@ -30,7 +30,9 @@
  */
 
 import no.nordicsemi.android.NordicPublishingExtension
+import no.nordicsemi.android.buildlogic.getGitRevision
 import no.nordicsemi.android.buildlogic.getVersionNameFromTags
+import no.nordicsemi.android.fixSpdx
 import no.nordicsemi.android.from
 import no.nordicsemi.android.tasks.ReleaseStagingRepositoriesTask
 import org.gradle.api.Plugin
@@ -50,6 +52,7 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters
+import org.spdx.sbom.gradle.SpdxSbomExtension
 import java.util.Calendar
 
 class PublishJvmConventionPlugin : Plugin<Project> {
@@ -61,10 +64,15 @@ class PublishJvmConventionPlugin : Plugin<Project> {
                 apply("maven-publish")
                 apply("signing")
                 apply("org.jetbrains.dokka")
+                apply("org.spdx.sbom")
             }
+
+            val gitVersion = getVersionNameFromTags()
+            val gitRevision = getGitRevision()
 
             // Default Nordic group.
             group = "no.nordicsemi.kotlin"
+            version = gitVersion
 
             val nordicPublishing = extensions.create("nordicPublishing", NordicPublishingExtension::class.java)
             val library = extensions.getByType<JavaPluginExtension>()
@@ -102,7 +110,7 @@ class PublishJvmConventionPlugin : Plugin<Project> {
                     }
                 }
                 // Set the version.
-                moduleVersion.set(getVersionNameFromTags())
+                moduleVersion.set(gitVersion)
                 // Set the footer message.
                 pluginsConfiguration.named("html", DokkaHtmlPluginParameters::class.java) {
                     val year = Calendar.getInstance().get(Calendar.YEAR)
@@ -133,6 +141,29 @@ class PublishJvmConventionPlugin : Plugin<Project> {
 
             // TODO Remove afterEvaluate when `artifactId` and `groupId` are converted to lazy properties.
             afterEvaluate {
+                // Configure SPDX SBOM generation.
+                extensions.configure<SpdxSbomExtension> {
+                    targets.register("release") {
+                        configurations.set(listOf("runtimeClasspath"))
+                        with (nordicPublishing) {
+                            scm {
+                                uri.set(pomScmUrl)
+                                revision.set(gitRevision)
+                            }
+                            document {
+                                // TODO Lazy proprties/
+                                name.set("$group:${pomArtifactId.get()}")
+                                namespace.set(pomUrl.map { "$it${pomArtifactId.get()}/$version/spdx" })
+                                creator.set(pomOrg.map { "Organization: $it" })
+                                packageSupplier.set(pomOrg.map { "Organization: $it" })
+                            }
+                        }
+                    }
+                }
+                val spdxTask = tasks.named("spdxSbomForRelease") {
+                    fixSpdx(project.group.toString(), nordicPublishing)
+                }
+
                 extensions.configure<PublishingExtension> {
                     repositories {
                         maven {
@@ -147,12 +178,13 @@ class PublishJvmConventionPlugin : Plugin<Project> {
                     publications {
                         val publication = create("library", MavenPublication::class.java) {
                             // Set publication properties.
-                            version = getVersionNameFromTags()
                             with(nordicPublishing) {
                                 // TODO Use artifactId.set(pomArtifactId) when they are converted to Property
                                 artifactId = pomArtifactId.get()
                                 // TODO same here
                                 groupId = pomGroup.getOrElse(group.toString())
+                                // TODO same here
+                                version = gitVersion
                             }
                             // Set the component to be published.
                             from(components["java"])
@@ -163,6 +195,12 @@ class PublishJvmConventionPlugin : Plugin<Project> {
                             }
                             // Add Dokka HTML docs.
                             artifact(tasks.named("dokkaHtmlJar"))
+
+                            // Add SPDX SBOM.
+                            artifact(spdxTask) {
+                                classifier = "sbom"
+                                extension = "json"
+                            }
                         }
                         // This task will add *.asc files to the publication for all artifacts.
                         signing.sign(publication)

--- a/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
+++ b/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
@@ -30,7 +30,9 @@
  */
 
 import no.nordicsemi.android.NordicPublishingExtension
+import no.nordicsemi.android.buildlogic.getGitRevision
 import no.nordicsemi.android.buildlogic.getVersionNameFromTags
+import no.nordicsemi.android.fixSpdx
 import no.nordicsemi.android.from
 import no.nordicsemi.android.tasks.ReleaseStagingRepositoriesTask
 import org.gradle.api.Plugin
@@ -51,6 +53,7 @@ import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters
+import org.spdx.sbom.gradle.SpdxSbomExtension
 import java.util.Calendar
 
 class PublishKmpConventionPlugin : Plugin<Project> {
@@ -67,10 +70,15 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                 apply("maven-publish")
                 apply("signing")
                 apply("org.jetbrains.dokka")
+                apply("org.spdx.sbom")
             }
+
+            val gitVersion = getVersionNameFromTags()
+            val gitRevision = getGitRevision()
 
             // Default Nordic group.
             group = "no.nordicsemi.kotlin"
+            version = gitVersion
 
             val nordicPublishing = extensions.create("nordicPublishing", NordicPublishingExtension::class.java)
             val signing = extensions.getByType<SigningExtension>()
@@ -101,7 +109,7 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                     }
                 }
                 // Set the version.
-                moduleVersion.set(getVersionNameFromTags())
+                moduleVersion.set(gitVersion)
                 // Set the footer message.
                 pluginsConfiguration.named("html", DokkaHtmlPluginParameters::class.java) {
                     val year = Calendar.getInstance().get(Calendar.YEAR)
@@ -131,6 +139,30 @@ class PublishKmpConventionPlugin : Plugin<Project> {
             }
 
             afterEvaluate {
+                // Configure SPDX SBOM generation.
+                extensions.configure<SpdxSbomExtension> {
+                    targets.register("release") {
+                        // By default, the 'configurations' have only 1 item: "runtimeClasspath".
+                        configurations.set(listOf("jvmRuntimeClasspath"))
+                        with (nordicPublishing) {
+                            scm {
+                                uri.set(pomScmUrl)
+                                revision.set(gitRevision)
+                            }
+                            document {
+                                // TODO Use name.set(pomArtifactId) when it is converted to Property
+                                name.set("$group:${pomArtifactId.get()}")
+                                namespace.set(pomUrl.map { "$it${pomArtifactId.get()}/$version/spdx" })
+                                creator.set(pomOrg.map { "Organization: $it" })
+                                packageSupplier.set(pomOrg.map { "Organization: $it" })
+                            }
+                        }
+                    }
+                }
+                val spdxTask = tasks.named("spdxSbomForRelease") {
+                    fixSpdx(project.group.toString(), nordicPublishing)
+                }
+
                 extensions.configure<PublishingExtension> {
                     repositories {
                         maven {
@@ -146,12 +178,13 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                     // Configure all of them with common settings.
                     publications.withType<MavenPublication>().configureEach {
                         // Set publication properties.
-                        version = getVersionNameFromTags()
                         with(nordicPublishing) {
                             // Note: artifactId should NOT be set for KMP modules.
                             //       Those are set automatically based on the platform.
                             // TODO Use groupId.set(pomGroup) when it is converted to Property
                             groupId = pomGroup.getOrElse(group.toString())
+                            // TODO Same here
+                            version = gitVersion
                         }
                         // Apply POM configuration.
                         pom {
@@ -159,6 +192,18 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                         }
                         // Add Dokka HTML docs.
                         artifact(tasks.named("dokkaHtmlJar"))
+
+                        // Only attach SBOM to the root KMP publication, not every platform artifact.
+                        // Note:
+                        //   If iOS module has some extra dependencies they won't be included here
+                        //   in the SBOM. If we reach this situation, we should perhaps add
+                        //   SBOM for iOS artifacts as well.
+                        if (name == "kotlinMultiplatform") {
+                            artifact(spdxTask) {
+                                classifier = "sbom"
+                                extension = "json"
+                            }
+                        }
                     }
                     // This task will add *.asc files to the publication for all artifacts.
                     signing.isRequired = isSigningEnabled

--- a/plugins/src/main/kotlin/no/nordicsemi/android/NordicPublishingExtension.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/NordicPublishingExtension.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.android
 
+import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.maven.MavenPom
@@ -168,5 +169,55 @@ internal fun MavenPom.from(
             organization.set(pomOrg.get())
             organizationUrl.set(pomOrgUrl.get())
         }
+    }
+}
+
+/**
+ * This method modifies the outcome of "spdxSbomForRelease" task and sets correct
+ * license and copyright information.
+ *
+ * Perhaps this will be removed in the future.
+ *
+ * See: [spdx-gradle-plugin](https://github.com/spdx/spdx-gradle-plugin).
+ */
+internal fun Task.fixSpdx(
+    group: String,
+    extension: NordicPublishingExtension,
+) {
+    doLast {
+        val sbomFile = outputs.files.singleFile
+        val json = groovy.json.JsonSlurper().parse(sbomFile) as MutableMap<*, *>
+
+        @Suppress("UNCHECKED_CAST")
+        val packages = json["packages"] as List<Map<String, Any>>
+
+        val nordicOrg = extension.pomOrg.get()
+        val license = extension.pomLicence.get()
+
+        val patched = packages.map { pkg ->
+            if (pkg["supplier"] == "Organization: $nordicOrg") {
+                pkg.toMutableMap().apply {
+                    // For libraries that are being released the license is not set.
+                    if (get("licenseDeclared") == "NOASSERTION") {
+                        put("licenseDeclared", license)
+                        put("licenseConcluded", license)
+                    }
+                    if (get("copyrightText") == "NOASSERTION") {
+                        put("copyrightText", "Copyright (c) ${java.time.Year.now()} $nordicOrg")
+                    }
+                    // The local packages are published with just the module name.
+                    // Instead, we want them to contain the group id.
+                    val moduleName = get("name").toString()
+                    if (!moduleName.contains(":")) {
+                        put("name", "$group:$moduleName")
+                    }
+                }
+            } else pkg
+        }
+
+        val output = groovy.json.JsonOutput.toJson(json.toMutableMap().apply {
+            put("packages", patched)
+        })
+        sbomFile.writeText(groovy.json.JsonOutput.prettyPrint(output))
     }
 }

--- a/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/GitVersion.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/GitVersion.kt
@@ -80,3 +80,16 @@ fun Project.getVersionNameFromTags(): String {
     // Version may have % to add additional information
     return latestTag.split("%")[0]
 }
+
+/**
+ * This method returns the current git revision.
+ */
+fun Project.getGitRevision(): String {
+    return try {
+        providers.exec { commandLine("git", "rev-parse", "HEAD") }
+            .standardOutput.asText.get().trim()
+    } catch (e: Exception) {
+        e.printStackTrace()
+        "main"
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        gradlePluginPortal()
     }
 }
 


### PR DESCRIPTION
This Plugin adds SPDX SBOM file generation into a Maven package.
For KMP module the *sbom.json* is added only to the main Kotlin Multiplatform package, not to platform-specific.

> [!Note]
> Dependencies are created based on JVM and Android dependencies, and for now may miss some *native* dependencies, if any is added to iOS/macOS dependency.