### PR TITLE
Removed unnecessary compiler argument after updating Kotlin to 2.4

### DIFF
--- a/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/KotlinAndroid.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/buildlogic/KotlinAndroid.kt
@@ -107,8 +107,6 @@ private inline fun <reified T : KotlinBaseExtension> Project.configureKotlin() =
         optIn.add("kotlin.RequiresOptIn")
         optIn.add("kotlinx.coroutines.ExperimentalCoroutinesApi")
         optIn.add("kotlinx.coroutines.FlowPreview")
-        // https://kotlinlang.org/docs/whatsnew23.html#explicit-backing-fields
-        freeCompilerArgs.add("-Xexplicit-backing-fields")
         // https://kotlinlang.org/docs/whatsnew23.html#unused-return-value-checker
         freeCompilerArgs.add("-Xreturn-value-checker=full")
 


### PR DESCRIPTION
This feature is not Stable in Kotlin 2.4.