### PR TITLE
Remove requirement for jvm() target for publishing libraries.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 minSdk = "23"
 androidGradlePlugin = "9.2.1"
-kotlin = "2.4.0" # When changes, update also kotlinAndroid.kt
+kotlin = "2.4.20-Beta2" # When changes, update also kotlinAndroid.kt
 ksp = "2.3.10"
 androidxActivity = "1.13.0"
 androidxAnnotation = "1.10.0"
@@ -74,7 +74,7 @@ slf4j = "2.0.18"
 slf4j-timber = "1.2"
 robolectric = "4.16.1"
 skydovesBallon = "1.7.6"
-skydovesCloudy = "0.7.0"
+skydovesCloudy = "0.7.1"
 moshi = "1.15.2"
 koin = "4.2.2"
 kmmVoyager = "2.2.21-1.10.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 minSdk = "23"
 androidGradlePlugin = "9.2.1"
-kotlin = "2.4.20-Beta2" # When changes, update also kotlinAndroid.kt
+kotlin = "2.4.0" # When changes, update also kotlinAndroid.kt
 ksp = "2.3.10"
 androidxActivity = "1.13.0"
 androidxAnnotation = "1.10.0"
@@ -74,7 +74,7 @@ slf4j = "2.0.18"
 slf4j-timber = "1.2"
 robolectric = "4.16.1"
 skydovesBallon = "1.7.6"
-skydovesCloudy = "0.7.1"
+skydovesCloudy = "0.7.0"
 moshi = "1.15.2"
 koin = "4.2.2"
 kmmVoyager = "2.2.21-1.10.3"

--- a/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
+++ b/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
@@ -143,7 +143,13 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                 extensions.configure<SpdxSbomExtension> {
                     targets.register("release") {
                         // By default, the 'configurations' have only 1 item: "runtimeClasspath".
-                        configurations.set(listOf("jvmRuntimeClasspath"))
+                        // Prefer the jvm target's runtime classpath, as it best represents the
+                        // full common dependency graph — but not every KMP module declares a
+                        // jvm() target, so fall back to whatever classpath configuration is
+                        // actually present instead of hardcoding one that may not exist.
+                        listOf("jvmRuntimeClasspath", "releaseRuntimeClasspath", "runtimeClasspath")
+                            .firstOrNull { project.configurations.findByName(it) != null }
+                            ?.let { configurations.set(listOf(it)) }
                         with (nordicPublishing) {
                             scm {
                                 uri.set(pomScmUrl)

--- a/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
+++ b/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
@@ -139,34 +139,47 @@ class PublishKmpConventionPlugin : Plugin<Project> {
             }
 
             afterEvaluate {
-                // Configure SPDX SBOM generation.
-                extensions.configure<SpdxSbomExtension> {
-                    targets.register("release") {
-                        // By default, the 'configurations' have only 1 item: "runtimeClasspath".
-                        // Prefer the jvm target's runtime classpath, as it best represents the
-                        // full common dependency graph — but not every KMP module declares a
-                        // jvm() target, so fall back to whatever classpath configuration is
-                        // actually present instead of hardcoding one that may not exist.
-                        listOf("jvmRuntimeClasspath", "releaseRuntimeClasspath", "runtimeClasspath")
-                            .firstOrNull { project.configurations.findByName(it) != null }
-                            ?.let { configurations.set(listOf(it)) }
-                        with (nordicPublishing) {
-                            scm {
-                                uri.set(pomScmUrl)
-                                revision.set(gitRevision)
-                            }
-                            document {
-                                // TODO Use name.set(pomArtifactId) when it is converted to Property
-                                name.set("$group:${pomArtifactId.get()}")
-                                namespace.set(pomUrl.map { "$it${pomArtifactId.get()}/$version/spdx" })
-                                creator.set(pomOrg.map { "Organization: $it" })
-                                packageSupplier.set(pomOrg.map { "Organization: $it" })
+                // Configure SPDX SBOM generation, resolved from the jvm target's runtime
+                // classpath as it best represents the full common dependency graph. Not every
+                // KMP module declares a jvm() target, and the other platforms' runtime
+                // classpaths aren't a safe substitute here: Android's (named
+                // "androidRuntimeClasspath" under the newer "Android Kotlin Multiplatform
+                // Library" AGP plugin) needs build-type/etc. variant attributes that a bare
+                // resolve like this doesn't supply, and fails with variant-ambiguity errors
+                // against any Android dependency exposing multiple variants. So modules without
+                // a jvm() target simply don't get an SBOM artifact, rather than crashing here or
+                // resolving one against an arbitrary/ambiguous variant.
+                val sbomClasspathConfiguration =
+                    "jvmRuntimeClasspath".takeIf { project.configurations.findByName(it) != null }
+                val spdxTask = sbomClasspathConfiguration?.let { classpathConfiguration ->
+                    extensions.configure<SpdxSbomExtension> {
+                        targets.register("release") {
+                            // By default, the 'configurations' have only 1 item: "runtimeClasspath".
+                            configurations.set(listOf(classpathConfiguration))
+                            with (nordicPublishing) {
+                                scm {
+                                    uri.set(pomScmUrl)
+                                    revision.set(gitRevision)
+                                }
+                                document {
+                                    // TODO Use name.set(pomArtifactId) when it is converted to Property
+                                    name.set("$group:${pomArtifactId.get()}")
+                                    namespace.set(pomUrl.map { "$it${pomArtifactId.get()}/$version/spdx" })
+                                    creator.set(pomOrg.map { "Organization: $it" })
+                                    packageSupplier.set(pomOrg.map { "Organization: $it" })
+                                }
                             }
                         }
                     }
-                }
-                val spdxTask = tasks.named("spdxSbomForRelease") {
-                    fixSpdx(project.group.toString(), nordicPublishing)
+                    tasks.named("spdxSbomForRelease") {
+                        fixSpdx(project.group.toString(), nordicPublishing)
+                    }
+                } ?: run {
+                    logger.log(
+                        LogLevel.WARN,
+                        "WARNING: Skipping SPDX SBOM generation for module ':$name' — no jvm() target declared, so there is no unambiguous runtime classpath to resolve it from."
+                    )
+                    null
                 }
 
                 extensions.configure<PublishingExtension> {
@@ -204,7 +217,7 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                         //   If iOS module has some extra dependencies they won't be included here
                         //   in the SBOM. If we reach this situation, we should perhaps add
                         //   SBOM for iOS artifacts as well.
-                        if (name == "kotlinMultiplatform") {
+                        if (name == "kotlinMultiplatform" && spdxTask != null) {
                             artifact(spdxTask) {
                                 classifier = "sbom"
                                 extension = "json"

--- a/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
+++ b/plugins/src/main/kotlin/PublishKmpConventionPlugin.kt
@@ -195,15 +195,26 @@ class PublishKmpConventionPlugin : Plugin<Project> {
                     }
                     // KMP creates publications automatically for each target.
                     // Configure all of them with common settings.
+                    val moduleName = project.name
                     publications.withType<MavenPublication>().configureEach {
                         // Set publication properties.
                         with(nordicPublishing) {
-                            // Note: artifactId should NOT be set for KMP modules.
-                            //       Those are set automatically based on the platform.
                             // TODO Use groupId.set(pomGroup) when it is converted to Property
                             groupId = pomGroup.getOrElse(group.toString())
                             // TODO Same here
                             version = gitVersion
+                            // Unlike single-platform modules, artifactId cannot just be set to
+                            // POM_ARTIFACT_ID here: KMP creates one publication per target and they
+                            // must keep distinct coordinates. Kotlin has already named them after the
+                            // Gradle module -- "<module>" for the root "kotlinMultiplatform"
+                            // publication and "<module>-<target>" for each platform one -- so replace
+                            // only that prefix and leave the platform suffix intact.
+                            //
+                            // Left unset, artifactId silently keeps the Gradle module name, which is
+                            // rarely what the module wants to be published as.
+                            pomArtifactId.orNull?.let {
+                                artifactId = it + artifactId.removePrefix(moduleName)
+                            }
                         }
                         // Apply POM configuration.
                         pom {


### PR DESCRIPTION
1. Remove the requirement for the jvm() target when publishing libraries.
2. Use the artifact ID as a prefix for published KMM libraries The full name will depend on the target they are built for (e.g. artifact-id-android, artifact-id-ios).