### PR TITLE
Do not force library consumers onto the newest compileSdk

### DIFF
--- a/plugins/src/main/kotlin/AndroidKmpLibraryConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidKmpLibraryConventionPlugin.kt
@@ -65,6 +65,12 @@ class AndroidKmpLibraryConventionPlugin : Plugin<Project> {
                         version = release(target.minSdk)
                     }
 
+                    // Without this, AGP 9 would publish minCompileSdk = COMPILE_SDK
+                    // and force every consumer onto the newest platform.
+                    aarMetadata {
+                        minCompileSdk = AppConst.MIN_COMPILE_SDK
+                    }
+
                     @Suppress("UnstableApiUsage")
                     optimization {
                         minify = false

--- a/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/plugins/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -58,6 +58,12 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
                 defaultConfig {
                     minSdk = target.minSdk
+
+                    // Without this, AGP 9 would publish minCompileSdk = COMPILE_SDK
+                    // and force every consumer onto the newest platform.
+                    aarMetadata {
+                        minCompileSdk = AppConst.MIN_COMPILE_SDK
+                    }
                 }
 
                 buildFeatures {

--- a/plugins/src/main/kotlin/no/nordicsemi/android/AppConsts.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/AppConsts.kt
@@ -11,15 +11,19 @@ object AppConst {
     /**
      * The lowest `compileSdk` a consumer of a published Nordic library may use.
      *
-     * Deliberately kept behind [COMPILE_SDK]. Since AGP 9.0 a library's AAR metadata
-     * defaults `minCompileSdk` to whatever the library itself compiled against, so
-     * without this every Nordic release would require every consumer to move to the
-     * newest platform at the same time. The AGP 9.0 release notes recommend setting
-     * `AarMetadata.minCompileSdk` explicitly "if you want to give consumers of a
-     * library you publish more time to switch".
+     * Since AGP 9.0 a library's AAR metadata defaults `minCompileSdk` to whatever the
+     * library itself compiled against, so without setting this, every Nordic release
+     * would require every consumer to move to the newest platform at the same time.
+     * The AGP 9.0 release notes recommend setting `AarMetadata.minCompileSdk`
+     * explicitly "if you want to give consumers of a library you publish more time to
+     * switch".
      *
-     * Bump this deliberately, and only when a Nordic library genuinely needs a
-     * resource or manifest attribute from a newer platform.
+     * This value is not derived from [COMPILE_SDK] and should not track it. What
+     * matters is the oldest platform a consumer can still compile a library's public
+     * API and resources against — for a library that ships no resources, that is no
+     * higher than its `minSdk`. Raise it only when a library genuinely uses a resource
+     * or manifest attribute from a newer platform, and prefer raising it for that
+     * library alone rather than for every published module.
      */
     const val MIN_COMPILE_SDK = 36
     val KOTLIN_VERSION = KotlinVersion.KOTLIN_2_4

--- a/plugins/src/main/kotlin/no/nordicsemi/android/AppConsts.kt
+++ b/plugins/src/main/kotlin/no/nordicsemi/android/AppConsts.kt
@@ -7,6 +7,21 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 object AppConst {
     const val COMPILE_SDK = 37
     const val TARGET_SDK = 37
+
+    /**
+     * The lowest `compileSdk` a consumer of a published Nordic library may use.
+     *
+     * Deliberately kept behind [COMPILE_SDK]. Since AGP 9.0 a library's AAR metadata
+     * defaults `minCompileSdk` to whatever the library itself compiled against, so
+     * without this every Nordic release would require every consumer to move to the
+     * newest platform at the same time. The AGP 9.0 release notes recommend setting
+     * `AarMetadata.minCompileSdk` explicitly "if you want to give consumers of a
+     * library you publish more time to switch".
+     *
+     * Bump this deliberately, and only when a Nordic library genuinely needs a
+     * resource or manifest attribute from a newer platform.
+     */
+    const val MIN_COMPILE_SDK = 36
     val KOTLIN_VERSION = KotlinVersion.KOTLIN_2_4
     val JAVA_SOURCE_VERSION = JavaVersion.VERSION_17
     val JAVA_TARGET_VERSION = JavaVersion.VERSION_17


### PR DESCRIPTION
## Problem

Since **AGP 9.0**, a library's AAR metadata defaults `minCompileSdk` to whatever the library itself compiled against. Because the convention plugins set `compileSdk` from `AppConst.COMPILE_SDK`, every published Nordic library now requires its consumers to compile against the newest platform as soon as Nordic moves to it.

Concretely, `no.nordicsemi.kotlin.ble:client-android:2.0.0-beta05` and `environment-android` both ship `minCompileSdk=37`, so an app on `compileSdk 36` fails at `checkAarMetadata` before anything is compiled.

The [AGP 9.0 release notes](https://developer.android.com/build/releases/agp-9-0-0-release-notes) call this out and give the remedy:

> Android Gradle plugin 9.0 by default requires consumers of a library to use the same or higher compile SDK version. […] If this is not possible, or you want to give consumers of a library you publish more time to switch, set `AarMetadata.minCompileSdk` explicitly.

## Why the inherited value is wrong here

To be clear, the Kotlin BLE Library genuinely does need `compileSdk 37` **to build**: `client-android/.../internal/BluetoothGatt.kt` uses `android.bluetooth.BluetoothGattConnectionSettings` and the `connectGatt(settings, executor, callback)` overload, which do not exist in `android-36`.

But that is precisely the situation `minCompileSdk` exists to decouple, because none of it reaches a consumer:

- the API 37 usage sits behind a `Build.VERSION.SDK_INT >= Build.VERSION_CODES.CINNAMON_BUN` guard, so it is a runtime concern, not a compile-time one for consumers;
- the published AARs ship **no resources at all** — no `res/` directory, `R.txt` is empty — so there is no resource-merge failure to protect against;
- the manifests carry only `uses-sdk` and the Bluetooth permissions, nothing from a newer platform;
- `SdkVersion.CINNAMON_BUN` in `core-android` is your own `const val … = 37`, which compiles at any `compileSdk`.

So what a consumer needs to compile against and what Nordic needs to compile against are genuinely different numbers, and right now the build system conflates them.

For reference, `JuulLabs/Kable` hit the same thing recently and fixed it the same way (JuulLabs/kable#1206 → JuulLabs/kable#1211).

## Change

Adds `AppConst.MIN_COMPILE_SDK` and applies it via `aarMetadata` in `AndroidLibraryConventionPlugin` and `AndroidKmpLibraryConventionPlugin`.

## On the value itself

**36 is a deliberately conservative default, not a principled one.** It is one release behind `COMPILE_SDK`, which buys consumers a single release of grace rather than genuinely decoupling the two numbers. If both keep moving together each year, a consumer two releases behind is broken again.

The more principled value is the library's own **`minSdk`**, which is what Kable chose. That derives from something real — the lowest `compileSdk` that can still compile against the library's public API — instead of an arbitrary offset, and it would give consumers years of runway rather than one release.

The reason I did not make that the default here is that these convention plugins are not only used by libraries like the BLE one. They also build libraries that genuinely ship resources — `no.nordicsemi.android.common:theme:2.11.1`, for instance, contains 23 `res/` entries. For those, a floor well below their `compileSdk` would turn a clear "raise your compileSdk" message into an obscure resource-not-found failure during resource merging, which is exactly what `minCompileSdk` exists to prevent. Judging that trade across your whole library surface is your call, not mine.

So, concretely, I am happy to do any of these — just say which you prefer:

1. Leave the conservative default as-is.
2. Change the default to `target.minSdk`, matching Kable, and accept the weaker error message for resource-carrying modules.
3. Keep a conservative default but make it overridable per module, so libraries that ship resources can raise it and the rest can sit at `minSdk`.

## Verification

Built `Kotlin-BLE-Library` (branch `version/2.0`, which pins `version-catalog-min-sdk-21:3.2`) against these plugins published to `mavenLocal`:

| Artifact | Before | After |
| --- | --- | --- |
| `client-android` | `minCompileSdk=37` | `minCompileSdk=36` |
| `environment-android` | `minCompileSdk=37` | `minCompileSdk=36` |

`:client-android:assembleRelease` and `:environment-android:assembleRelease` both succeed unchanged. `:plugins:compileKotlin` is clean, including the KMP plugin — `aarMetadata` is available on `KotlinMultiplatformAndroidLibraryTarget`.

Separately, and as evidence that a lower `minCompileSdk` is safe rather than merely convenient: we compiled the BLE library's sources at `compileSdk 37`, declared `minCompileSdk 36`, and built a consumer application at a flat `compileSdk 36` with no bypass flags. It compiles, dexes and packages, with Nordic's classes present in the APK. Nothing about compiling against 37 required the consumer to.

## Context

We maintain a BLE SDK built on the Kotlin BLE Library, and we have customers who are not ready to move to `compileSdk 37` yet. Happy to split the KMP change out or take a different approach entirely if you would rather solve it another way.
